### PR TITLE
fixes #34 (ipv6 and ipv4 for snapserver)

### DIFF
--- a/group_vars/amsel_acables_analog_snapserver_mpd/main.yml
+++ b/group_vars/amsel_acables_analog_snapserver_mpd/main.yml
@@ -5,7 +5,6 @@ acable_config:
     source: dsnoop:CARD=sndrpihifiberry,DEV=0
     sink: dmix:CARD=Loopback,DEV=0
 
-snapserver_name: sspidev
 snapserver_sourcetype: alsa
 snapserver_alsasource: dsnoop:CARD=Loopback,DEV=1
 

--- a/group_vars/amsel_acables_bluetooth_analog_snapserver_mpd/main.yml
+++ b/group_vars/amsel_acables_bluetooth_analog_snapserver_mpd/main.yml
@@ -7,7 +7,6 @@ acable_config:
     source: dsnoop:CARD=sndrpihifiberry,DEV=0
     sink: dmix:CARD=Loopback,DEV=0
 
-snapserver_name: sspidev
 snapserver_sourcetype: alsa
 snapserver_alsasource: dsnoop:CARD=Loopback,DEV=1
 

--- a/roles/snapserver/defaults/main.yml
+++ b/roles/snapserver/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-snapserver_name: snapname
+snapserver_name: "{{ ansible_hostname }}"
 snapserver_sourcetype: alsa
 snapserver_alsasource: dsnoop:CARD=Loopback,DEV=1
 snapserver_sampleformat: "44100:16:2"

--- a/roles/snapserver/templates/etc/snapserver.conf.j2
+++ b/roles/snapserver/templates/etc/snapserver.conf.j2
@@ -60,6 +60,8 @@
 # use the address of a specific network interface to just listen to and accept
 # connections from that interface
 #bind_to_address = 0.0.0.0
+# although not clearly documented, this enables both IPv6 and IPv4:
+bind_to_address = ::
 
 # which port the server should listen to
 #port = 1780
@@ -83,6 +85,8 @@ doc_root = /usr/share/snapserver/snapweb
 # use the address of a specific network interface to just listen to and accept
 # connections from that interface
 #bind_to_address = 0.0.0.0
+# although not clearly documented, this enables both IPv6 and IPv4:
+bind_to_address = ::
 
 # which port the server should listen to
 #port = 1705
@@ -99,6 +103,8 @@ doc_root = /usr/share/snapserver/snapweb
 # use the address of a specific network interface to just listen to and accept
 # connections from that interface
 #bind_to_address = 0.0.0.0
+# although not clearly documented, this enables both IPv6 and IPv4:
+bind_to_address = ::
 
 # which port the server should listen to
 #port = 1704


### PR DESCRIPTION
Tested on `pidev`, works:
~~~
root@pidev:/home/pi# lsof -i | grep snapserv
snapserve 15508 _snapserver   12u  IPv6 6323320      0t0  TCP *:1705 (LISTEN)
snapserve 15508 _snapserver   13u  IPv6 6323321      0t0  TCP *:1780 (LISTEN)
snapserve 15508 _snapserver   14u  IPv6 6323324      0t0  TCP *:1704 (LISTEN)
~~~