### PR TITLE
Added longer snapserver buffer size

### DIFF
--- a/group_vars/amsel_server/main.yml
+++ b/group_vars/amsel_server/main.yml
@@ -2,6 +2,7 @@
 snapserver_sourcetype: alsa
 snapserver_alsasource: dsnoop:CARD=Loopback,DEV=1
 snapserver_idle_threshold: 30000
+snapserver_buffer: 1000
 
 mpd_music_directory: "smb://shares.t7.iselin.net/mp3-coll"
 mpd_alsa_sink_name: "To Snapserver"


### PR DESCRIPTION
This reduces dropouts in case e.g. of instable WLAN connection