### PR TITLE
feat: make raspotify log level configurable

### DIFF
--- a/roles/raspotify/defaults/main.yml
+++ b/roles/raspotify/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 raspotify_name: "Snapcast"
+raspotify_verbose: false
 raspotify_bitrate: "320"
 raspotify_format: "S16"
 raspotify_device_type: "speaker"

--- a/roles/raspotify/templates/etc/raspotify/conf.j2
+++ b/roles/raspotify/templates/etc/raspotify/conf.j2
@@ -41,7 +41,11 @@ LIBRESPOT_DISABLE_CREDENTIAL_CACHE=
 LIBRESPOT_ENABLE_VOLUME_NORMALISATION=
 
 # Enable verbose log output.
+{% if raspotify_verbose is defined and raspotify_verbose -%}
+LIBRESPOT_VERBOSE=
+{% else %}
 #LIBRESPOT_VERBOSE=
+{% endif %}
 
 # Disable zeroconf discovery mode.
 #LIBRESPOT_DISABLE_DISCOVERY=


### PR DESCRIPTION
currently only "enable" or "disable" verbose supported.