### PR TITLE
chore: cleanup github pkg use

### DIFF
--- a/multiroom-amsel.yml
+++ b/multiroom-amsel.yml
@@ -8,9 +8,10 @@
 ### * "bluetooth_disable" should be executed for all hosts without any acable
 ###    configured if you want to be sure that bluetooth is actually switched off.
 ### * At least one audio server (snapserver) should be defined to actually distribute
-###   audio). This needs snd_aloop, snapserver/snapweb and mpd.
+###   audio). This needs snd_aloop, snapserver (plus snapweb when snapserver from
+###   bullseye is used). And at least one of mpd and raspotify.
 
-### base/snapclient 
+### base/snapclient
 
 - name: Run base and snapclient role on all hosts
   hosts: amsel_all
@@ -41,7 +42,7 @@
   roles:
     - snd_aloop
     - snapserver
-    - snapweb
+    #- snapweb
 
 - name: Configure full audio server (including mpd, raspotify)
   hosts: amsel_server
@@ -49,6 +50,6 @@
   roles:
     - snd_aloop
     - snapserver
-    - snapweb
+    #- snapweb
     - mpd
     - raspotify

--- a/roles/snapserver/defaults/main.yml
+++ b/roles/snapserver/defaults/main.yml
@@ -8,7 +8,7 @@ snapserver_codec: flac
 snapserver_buffer: 200
 # set snapserver_from_github to true in host vars to make the following work
 snapserver_github_source: "https://github.com/badaix/snapcast/releases/download/v0.27.0/snapserver_0.27.0-1_armhf.deb"
-snapserver_github_dest: "/tmp/snapserver_0.27.0-1_armhf.deb"
+snapserver_github_dest: "/var/tmp/snapserver_0.27.0-1_armhf.deb"
 snapserver_github_sha256sum: "bdfe79e76dfe37a61190942ec0788ec49d300dca1789ef2f0f722dbdccf755e8"
 snapserver_idle_threshold: 1000
 snapserver_silence_threshold_percent: "0.5"


### PR DESCRIPTION
It was a bad idea to store the downloaded pkg in /tmp: This triggers an ansible change if the target was rebooted.

As the github pkg works really well, I don't need the snapweb role any more in my amsel setup.