### PR TITLE
feat: bookworm support for most roles

### DIFF
--- a/group_vars/amsel_all/main.yml
+++ b/group_vars/amsel_all/main.yml
@@ -7,7 +7,7 @@ snapclient_config:
   - name: wohnen
     snapclient_snapserver: wohnen.iselin.net
     snapclient_sink: dmix:CARD=sndrpihifiberry,DEV=0
-  - name: balkon
-    snapclient_snapserver: balkon.iselin.net
+  - name: pi4dev
+    snapclient_snapserver: pi4dev.iselin.net
     snapclient_sink: dmix:CARD=sndrpihifiberry,DEV=0
 

--- a/inventory_amsel
+++ b/inventory_amsel
@@ -6,8 +6,8 @@ spielen
 schlaf
 chuchi
 badhell
-# pidev
-balkon
+pi4dev
+# balkon
 
 ### Internal Audio connections
 # Stream the Hifi-Rec-Out to aloop/snapserver
@@ -23,6 +23,7 @@ spielen
 [amsel_bluetooth_aloop]
 wohnen
 spielen
+pi4dev
 
 # Stream Bluetooth to hw out (watch TV, no need to distribute)
 [amsel_bluetooth_dac]
@@ -36,4 +37,5 @@ balkon
 [amsel_server]
 wohnen
 spielen
+pi4dev
 

--- a/multiroom-amsel.yml
+++ b/multiroom-amsel.yml
@@ -42,7 +42,6 @@
   roles:
     - snd_aloop
     - snapserver
-    #- snapweb
 
 - name: Configure full audio server (including mpd, raspotify)
   hosts: amsel_server
@@ -50,6 +49,6 @@
   roles:
     - snd_aloop
     - snapserver
-    #- snapweb
     - mpd
+    - mpdutils
     - raspotify

--- a/roles/acable/tasks/main.yml
+++ b/roles/acable/tasks/main.yml
@@ -9,14 +9,9 @@
   ansible.builtin.copy:
     src: files/usr/local/bin/acable.sh
     dest: /usr/local/bin/acable.sh
+    mode: "0755"
     backup: yes
   notify: Restart acables
-
-- name: Make acable script executable
-  ansible.builtin.file:
-    dest: /usr/local/bin/acable.sh
-    mode: +x
-  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Create acable.conf.d directory
   ansible.builtin.file:

--- a/roles/bluetooth_sink/handlers/bluetoothd.yml
+++ b/roles/bluetooth_sink/handlers/bluetoothd.yml
@@ -6,3 +6,8 @@
     daemon_reload: yes
     state: restarted
   ignore_errors: "{{ ansible_check_mode }}"
+
+- name: Force discoverablity
+  ansible.builtin.command:
+    cmd: bluetoothctl discoverable on
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/bluetooth_sink/tasks/bluealsa.yml
+++ b/roles/bluetooth_sink/tasks/bluealsa.yml
@@ -5,9 +5,24 @@
     msg: "ERROR: os_family of host {{ inventory_hostname }} is not Debian"
   when: ansible_facts['os_family'] != "Debian"
 
-- block:
+# install bluealsa. What a mess since I started to use backports.
+
+- name: Install bluealsa for pre bullseye
+  when: ansible_facts['distribution_major_version'] | int < 11
+  block:
+
+  - name: Install bluealsa package
+    ansible.builtin.apt:
+      name: bluealsa
+      state: latest
+      update_cache: yes
+
+- name: Add bookworm repo at low prio to use of bluez-alsa
+  when: ansible_facts['distribution_major_version'] == '11'
+  block:
+
   - name: Add "bookworm" testing release
-    ansible.builtin.apt_repository: 
+    ansible.builtin.apt_repository:
       repo: deb http://archive.raspbian.org/raspbian bookworm main contrib non-free rpi
       state: present
 
@@ -16,17 +31,30 @@
       src: files/etc/apt/preferences.d/preferbullseye.pref
       dest: /etc/apt/preferences.d/preferbullseye.pref
 
+- name: Remove bluealsa, add bluez-alsa
+  when: ansible_facts['distribution_major_version'] | int >= 11
+
+  block:
   - name: Ensure old bluealsa package is removed
     ansible.builtin.apt:
       name: bluealsa
       state: absent
 
-  - name: Install bluez-alsa from bookworm
+  - name: Install bluez-alsa
     ansible.builtin.apt:
       name: bluez-alsa-utils
       state: latest
       update_cache: yes
 
+# the service name does not match the package name. The service
+# was called bluez-alsa only in the backported pkg...
+# older       bluealsa.service             , needs systemd overlay
+# bullseye 11 bluez-alsa.service (backport), supports /etc/default
+# bookworm 12 bluealsa.service             , needs systemd overlay, has bluealsa-aplay.service
+
+- name: Configure and start bluez-alsa
+  when: ansible_facts['distribution_major_version'] | int == 11
+  block:
   - name: Configure bluez-alsa in /etc/default
     ansible.builtin.lineinfile:
       path: /etc/default/bluez-alsa
@@ -35,6 +63,7 @@
       state: present
       backup: no
     notify: "Restart bluez-alsa"
+    ignore_errors: "{{ ansible_check_mode }}"
 
   - name: Start and enable bluez-alsa.service
     ansible.builtin.systemd:
@@ -44,14 +73,9 @@
       state: started
     ignore_errors: "{{ ansible_check_mode }}"
 
-  when: ansible_facts['distribution_release'] == "bullseye"
-
-- block:
-  - name: Install bluealsa package (for older releases)
-    ansible.builtin.apt:
-      name: bluealsa
-      state: latest
-      update_cache: yes
+- name: Configure and start bluealsa
+  when: ansible_facts['distribution_major_version'] | int != 11
+  block:
 
   - name: Create systemd override directory for bluealsa
     ansible.builtin.file:
@@ -74,4 +98,12 @@
       state: started
     ignore_errors: "{{ ansible_check_mode }}"
 
-  when: ansible_facts['distribution_release'] != "bullseye"
+- name: Stop, disable and mask bluealsa-aplay service
+  when: ansible_facts['distribution_major_version'] | int > 11
+  ansible.builtin.systemd:
+    name: "bluealsa-aplay.service"
+    enabled: no
+    daemon_reload: yes
+    state: stopped
+    masked: yes
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/bluetooth_sink/tasks/bluetoothd.yml
+++ b/roles/bluetooth_sink/tasks/bluetoothd.yml
@@ -19,18 +19,6 @@
     option: DiscoverableTimeout
     value: "0"
     backup: yes
-  notify: "Restart bluetoothd"
-
-- name: Check if device is discoverable
-  ansible.builtin.shell:
-    cmd: /usr/bin/bluetoothctl show | egrep -o "Discoverable. .*" | cut -d " " -f 2
-  register: bluetoothd_discoverable
-  changed_when: false
-
-- name: Make device discoverable
-  ansible.builtin.command:
-    cmd: /usr/bin/bluetoothctl discoverable on
-  when:
-    - bluetoothd_discoverable.stdout == "no"
-    - not ansible_check_mode
-  ignore_errors: "{{ ansible_check_mode }}"
+  notify:
+    - Restart bluetoothd
+    - Force discoverablity

--- a/roles/mpd/tasks/main.yml
+++ b/roles/mpd/tasks/main.yml
@@ -18,6 +18,7 @@
     enabled: true
   when: mpd_zeroconf_enabled is not defined or not mpd_zeroconf_enabled
   notify: "Restart mpd"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Disable/Stop mpd socket (with zeroconf)
   ansible.builtin.systemd:

--- a/roles/mpd/templates/etc/mpd.conf.j2
+++ b/roles/mpd/templates/etc/mpd.conf.j2
@@ -9,7 +9,9 @@ zeroconf_name           "mpd@%h"
 music_directory         "{{ mpd_music_directory }}"
 playlist_directory      "/var/lib/mpd/playlists"
 db_file                 "/var/lib/mpd/tag_cache"
+{% if ansible_facts.distribution_major_version | int < 12 %}
 log_file                "/var/log/mpd/mpd.log"
+{% endif %}
 pid_file                "/run/mpd/pid"
 state_file              "/var/lib/mpd/state"
 sticker_file            "/var/lib/mpd/sticker.sql"

--- a/roles/raspotify/tasks/main.yml
+++ b/roles/raspotify/tasks/main.yml
@@ -29,4 +29,3 @@
     dest: /etc/raspotify/conf
     backup: yes
   notify: "Restart raspotify"
-

--- a/roles/snapserver/defaults/main.yml
+++ b/roles/snapserver/defaults/main.yml
@@ -7,9 +7,15 @@ snapserver_sampleformat: "44100:16:2"
 snapserver_codec: flac
 snapserver_buffer: 200
 # set snapserver_from_github to true in host vars to make the following work
-snapserver_github_source: "https://github.com/badaix/snapcast/releases/download/v0.27.0/snapserver_0.27.0-1_armhf.deb"
-snapserver_github_dest: "/var/tmp/snapserver_0.27.0-1_armhf.deb"
-snapserver_github_sha256sum: "bdfe79e76dfe37a61190942ec0788ec49d300dca1789ef2f0f722dbdccf755e8"
+snapserver_github:
+  - release: bullseye
+    source: "https://github.com/badaix/snapcast/releases/download/v0.27.0/snapserver_0.27.0-1_armhf.deb"
+    dest: "/var/tmp/snapserver_0.27.0-1_armhf.deb"
+    sha256sum: "bdfe79e76dfe37a61190942ec0788ec49d300dca1789ef2f0f722dbdccf755e8"
+  - release: bookworm
+    source: "https://github.com/badaix/snapcast/releases/download/v0.28.0/snapserver_0.28.0-1_armhf-bookworm.deb"
+    dest: "/var/tmp/snapserver_0.28.0-1_armhf-bookworm.deb"
+    sha256sum: "8b8d072a1846518fad8f951866520f5ac8540cdede3548084f42614f003a31b8"
 snapserver_idle_threshold: 1000
 snapserver_silence_threshold_percent: "0.5"
 snapserver_initial_volume: 10

--- a/roles/snapserver/tasks/main.yml
+++ b/roles/snapserver/tasks/main.yml
@@ -16,13 +16,13 @@
 
   - name: Get newest release from github
     ansible.builtin.get_url:
-      url: "{{ snapserver_github_source }}"
-      checksum: "sha256:{{ snapserver_github_sha256sum }}"
-      dest: "{{ snapserver_github_dest }}"
+      url: "{{ snapserver_github | selectattr('release', 'equalto', ansible_facts.distribution_release) | map(attribute='source') | first }}"
+      checksum: "sha256:{{ snapserver_github | selectattr('release', 'equalto', ansible_facts.distribution_release) | map(attribute='sha256sum') | first}}"
+      dest: "{{ snapserver_github | selectattr('release', 'equalto', ansible_facts.distribution_release) | map(attribute='dest') | first }}"
 
   - name: Install dowloaded package
     ansible.builtin.apt:
-      deb: "{{ snapserver_github_dest }}"
+      deb: "{{ snapserver_github | selectattr('release', 'equalto', ansible_facts.distribution_release) | map(attribute='dest') | first }}"
     notify:
       - Restart snapserver
     ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
I redeployed one of my raspis from scratch recently. Not all roles were ready for Rasperry OS / Debian bookworm yet. I (`amsel`) am running a mixed bullseye/bookworm environment and the following roles work on both releases now:

* base
* snapclient
* snd_aloop
* raspotify 
* mpd, mpdutils
* snapserver
* acable/bluethooth_sink (in bluetooth_workaround mode), 
* bluetooth_disable 

known todos:
* remove `snapweb`  role, this is now part of snapcast

untested yet: the ones that add the "camper" features:
* accesspoint
* uplink
* usbmount