### PR TITLE
upgrade to snapserver 0.34, configure controlscript, support persistent smb mount

### DIFF
--- a/group_vars/amsel_server/main.yml
+++ b/group_vars/amsel_server/main.yml
@@ -5,7 +5,11 @@ snapserver_from_github: true
 snapserver_idle_threshold: 30000
 snapserver_buffer: 1000
 
-mpd_music_directory: "smb://shares.t7.iselin.net/mp3-coll"
+mpd_smb_mount_music_dir: True
+mpd_smb_mount_music_dir_user: mp3readonly
+mpd_smb_mount_music_dir_password: unset
+mpd_smb_mount_music_dir_domain: T7
+mpd_smb_mount_music_dir_src: "//ucssmb.t7.iselin.net/mp3-coll"
 mpd_alsa_sink_name: "To Snapserver"
 mpd_alsa_sink_device: "dmix:CARD=Loopback,DEV=0"
 

--- a/roles/mpd/README.md
+++ b/roles/mpd/README.md
@@ -7,13 +7,25 @@ This role installs and configures an mpd on the host. The current configuration 
     * `false` disables zerconf in the `mpd` configuration and (starts and) enables `mpd.socket`.
 * `mpd_music_directory:` supported by the current template: just a local path like `/var/lib/mpd/music` or (ideally) a read only SMB guest share like `smb://myshare.mydomain.ch/music`. Can be checked e.g. with `mpc -h localhost mount`
 * `mpd_max_output_buffer_size:` Defaults to `32768`, prevents issues with a large collection and certain mpd clients.
-* the only mpd sink currently supported is an alsa sink, usually consumed via an ALSA loopback from the snapserver: 
+* the only mpd sink currently supported is an alsa sink, usually consumed via an ALSA loopback from the snapserver:
     * `mpd_alsa_sink_name:` an arbitrary sink name, visible e.g. with `mpc -h localhost outputs`. Defaults to `To Snapserver`.
     * `mpd_alsa_sink_device:` the alsa sink, defaults to `dmix:CARD=Loopback,DEV=0`. While this makes sense for a snapserver based setup, you might want to change this e.g. to `dmix:CARD=sndrpihifiberry,DEV=0`. Do not use `hw`, this would prevent other audio connections (e.g. via bluetooth) from accessing the alsa device.
     * `mpd_alsa_sink_format:` the format, defaults to `44100:16:2`.
     * `mpd_alsa_sink_mixer_type:` Defaults to `software`, which is appropriate when feeding audio to snapserver. In a single host setup, it makes sense to set this to `hardware`. In this case, two additional parameters are used
     * `mpd_alsa_sink_mixer_device:` Defaults to `hw:CARD=sndrpihifiberry`.
     * `mpd_alsa_sink_mixer_control:` Defaults to `Digital`.
+
+## Mounting mpd music dir via fstab
+
+When `mpd` encounters the music directory to start with `smb://` it uses `libsmbclient` to connect to the Samba Share. This usually works, but `libsmbclient` [is not thread safe and apparently won't ever be](https://github.com/MusicPlayerDaemon/MPD/issues/991). Therefore, there is also support for mounting the music directory via fstab (but this doesn't work anonymously).
+
+* `mpd_smb_mount_music_dir`: defaults to `False`. If set to `True`, the following variables become important:
+    * `mpd_smb_mount_music_dir_src`: The description of the remote share, e.g. `//myshare.mydomain.ch/music`
+    * `mpd_smb_mount_music_dir_user`: the smb user used to logon to the Samba Share
+    * `mpd_smb_mount_music_dir_password`: the password for that user. Defaults to `unset` which causes the role to interactively ask for it as long as the share is not mounted: If the share is already mounted, the credentials must be correct so there is no need to update them.
+    * `mpd_smb_mount_music_dir_domain`: the Samba Domain. These three variables get written to the `/etc/mpd_mount.creds` file that will be referred to by the mount entry created in `/etc/fstab`
+
+Note that it is an error to have `mpd_music_directory` start with `smb://` **and** setting `mpd_smb_mount_music_dir` to `True` at the same time.
 
 ## Hints to configure hardware mixing
 

--- a/roles/mpd/defaults/main.yml
+++ b/roles/mpd/defaults/main.yml
@@ -3,6 +3,7 @@
 mpd_zeroconf_enabled: false
 mpd_connection_timeout: 120
 
+mpd_smb_mount_music_dir: False
 mpd_music_directory: "/var/lib/mpd/music"
 mpd_max_output_buffer_size: "32768"
 

--- a/roles/mpd/tasks/main.yml
+++ b/roles/mpd/tasks/main.yml
@@ -5,6 +5,46 @@
     msg: "ERROR: os_family of host {{ inventory_hostname }} is not Debian"
   when: ansible_facts['os_family'] != "Debian"
 
+- name: Verify variable consistency
+  ansible.builtin.assert:
+    that: (mpd_smb_mount_music_dir and not mpd_music_directory is ansible.builtin.regex('^smb://') ) or not mpd_smb_mount_music_dir
+
+- name: Get current mountdir from ansible_mounts
+  when: mpd_smb_mount_music_dir
+  ansible.builtin.set_fact:
+    mpd_smb_mount_current: "{{ ansible_mounts | selectattr('device', 'eq', mpd_smb_mount_music_dir_src ) | map(attribute='mount') |  first | default('not mounted') }}"
+
+- name: Get password and create credentials file
+  when: mpd_smb_mount_music_dir and not mpd_smb_mount_current == mpd_music_directory
+  block:
+  - name: Get password if unset
+    delegate_to: localhost
+    run_once: True
+    when: mpd_smb_mount_music_dir_password == "unset"
+    block:
+    - name: Need password for {{ mpd_smb_mount_music_dir_user }}
+      ansible.builtin.pause:
+      register: _mpd_pause_result
+
+    - name: Save password to mpd_smb_mount_music_dir_password
+      ansible.builtin.set_fact:
+        mpd_smb_mount_music_dir_password: "{{ _mpd_pause_result.user_input }}"
+
+  - name: create credentials file
+    ansible.builtin.template:
+      src: etc/mpd_mount.creds.j2
+      dest: /etc/mpd_mount.creds
+      mode: "600"
+
+- name: Mount mpd_music_directory {{ mpd_music_directory }} from {{ mpd_smb_mount_music_dir_src }}
+  ansible.posix.mount:
+    fstype: smb3
+    opts: "defaults,ro,nosuid,nodev,noexec,soft,vers=3.0,credentials=/etc/mpd_mount.creds"
+    path: "{{ mpd_music_directory }}"
+    src: "{{ mpd_smb_mount_music_dir_src }}"
+    state: mounted
+    backup: true
+
 - name: Install mpd package
   ansible.builtin.apt:
     name: mpd
@@ -40,7 +80,7 @@
 
 - name: Configure mpd
   ansible.builtin.template:
-    src: templates/etc/mpd.conf.j2
+    src: etc/mpd.conf.j2
     dest: /etc/mpd.conf
     backup: yes
   notify: "Restart mpd"

--- a/roles/mpd/tasks/main.yml
+++ b/roles/mpd/tasks/main.yml
@@ -37,6 +37,7 @@
       mode: "600"
 
 - name: Mount mpd_music_directory {{ mpd_music_directory }} from {{ mpd_smb_mount_music_dir_src }}
+  when: mpd_smb_mount_music_dir
   ansible.posix.mount:
     fstype: smb3
     opts: "defaults,ro,nosuid,nodev,noexec,soft,vers=3.0,credentials=/etc/mpd_mount.creds"

--- a/roles/mpd/templates/etc/mpd.conf.j2
+++ b/roles/mpd/templates/etc/mpd.conf.j2
@@ -30,11 +30,12 @@ input {
         plugin "curl"
 }
 
-
-input { 
+{% if mpd_music_directory is ansible.builtin.regex('^smb://') -%}
+input {
         plugin "smbclient"
 }
 
+{% endif %}
 input {
        plugin "alsa"
        default_format "{{ mpd_alsa_sink_format }}"

--- a/roles/mpd/templates/etc/mpd_mount.creds.j2
+++ b/roles/mpd/templates/etc/mpd_mount.creds.j2
@@ -1,0 +1,3 @@
+username={{ mpd_smb_mount_music_dir_user }}
+password={{ mpd_smb_mount_music_dir_password }}
+domain={{ mpd_smb_mount_music_dir_domain }}

--- a/roles/snapserver/README.md
+++ b/roles/snapserver/README.md
@@ -15,23 +15,29 @@ Nov 25 20:32:49 pidev snapserver[12587]: Buffer is less than 400ms, changing to 
 Nov 25 20:32:49 pidev snapserver[12587]: PcmStream: sspidev, sampleFormat: 44100:16:2
 ~~~
 
-Two features I really like are not available from the snapserver package
-in the bullseye version: The **idle** detection that allows to treat
-analogue "almost silence" as real silence and the **initial volume** that
-is assigned to new snapclients (which is 100% without this feature).
+## Using github packages
 
-By setting one control variable, you can make the snapserver role to use the
-[package published on github](https://github.com/badaix/snapcast/releases)
-as package source.
+As debian/raspbian is quite slow in updating distributed packages, this role allows
+to use a [package published on github](https://github.com/snapcast/snapcast/releases)
+
+* `snapserver_from_github`: set to true to enable to fetch the package from github
+* `snapserver_github_source`: set in defaults to the latest version
+* `snapserver_github_dest`: set in defaults to `/var/tmp/...`
+* `snapserver_github_sha256sum`: Checksum of the package file
 
 **Please note**: if you switch from the raspbian to the github version, you
 need to manually remove `/var/lib/snapserver/` **before** you let the playbook
 install the package.
 
-* `snapserver_from_github`: set to true to enable to fetch the package from github
-* `snapserver_github_source`: set in defaults to the latest version
-* `snapserver_github_dest`: set in defaults to `/tmp/...`
-* `snapserver_github_sha256sum`: Checksum of the package file
-* `snapserver_idle_threshold`: snapserver switches to "silence" when audio is below the silence level for longer than the amount of milliseconds
-* `snapserver_idle_percent`: the maximum audio level in percent that is still considered as silence
-* `snapserver_initial_volume`: the volume a new (i.e. unknown in `/var/lib/snapserver/server.json`) snapclient gets assigned to.
+## Features available starting with v0.27
+
+* **idle** detection that allows to treat analogue "almost silence" as
+real silence
+  * `snapserver_idle_threshold`: snapserver switches to "silence" when audio is below the silence level for longer than the amount of milliseconds
+  * `snapserver_idle_percent`: the maximum audio level in percent that is still considered as silence
+* **initial volume** that is assigned to new snapclients
+  (which is 100% without this feature).
+  * `snapserver_initial_volume`: the volume a new (i.e. unknown in `/var/lib/snapserver/server.json`) snapclient gets assigned to.
+* **control script** to make SnapWeb even more useful by integrating to mpd.
+  * `snapserver_controlscript`: defaults to `meta_mpd.py`
+  * `snapserver_controlscript_enable_debugging`: defaults to `False`

--- a/roles/snapserver/defaults/main.yml
+++ b/roles/snapserver/defaults/main.yml
@@ -19,4 +19,5 @@ snapserver_github:
 snapserver_idle_threshold: 1000
 snapserver_silence_threshold_percent: "0.5"
 snapserver_initial_volume: 10
-
+snapserver_controlscript: "meta_mpd.py"
+snapserver_controlscript_enable_debugging: False

--- a/roles/snapserver/defaults/main.yml
+++ b/roles/snapserver/defaults/main.yml
@@ -13,9 +13,9 @@ snapserver_github:
     dest: "/var/tmp/snapserver_0.27.0-1_armhf.deb"
     sha256sum: "bdfe79e76dfe37a61190942ec0788ec49d300dca1789ef2f0f722dbdccf755e8"
   - release: bookworm
-    source: "https://github.com/badaix/snapcast/releases/download/v0.29.0/snapserver_0.29.0-1_armhf_bookworm.deb"
-    dest: "/var/tmp/snapserver_0.29.0-1_armhf-bookworm.deb"
-    sha256sum: "23e3f10e37038a768ca96e81695edbb5a38d6dac1842baa3f9359a6e016aa9a1"
+    source: "https://github.com/snapcast/snapcast/releases/download/v0.34.0/snapserver_0.34.0-1_armhf_bookworm.deb"
+    dest: "/var/tmp/snapserver_0.34.0-1_armhf-bookworm.deb"
+    sha256sum: "69b91bc180fa5f62a0487a3255e970b737150765eae20b9bf5cc1dc802c8f48f"
 snapserver_idle_threshold: 1000
 snapserver_silence_threshold_percent: "0.5"
 snapserver_initial_volume: 10

--- a/roles/snapserver/tasks/main.yml
+++ b/roles/snapserver/tasks/main.yml
@@ -30,6 +30,22 @@
   when: snapserver_from_github is defined and snapserver_from_github
   notify: Restart snapserver
 
+- name: Set variables for controlscript debugging
+  ansible.builtin.set_fact:
+    _snapserver_controlscript_params: "&controlscriptparams=--debug"
+    _snapserver_log_filter: 'PcmStream:debug,Script:debug,'
+  when:
+    - snapserver_controlscript is defined
+    - snapserver_controlscript != ""
+    - snapserver_controlscript_enable_debugging is defined
+    - snapserver_controlscript_enable_debugging
+
+- name: Unset variables for controlscript debugging
+  ansible.builtin.set_fact:
+    _snapserver_controlscript_params: ""
+    _snapserver_log_filter: ""
+  when: _snapserver_controlscript_params is not defined or _snapserver_controlscript_params == ''
+
 - name: Install snapserver config
   ansible.builtin.template:
     src: templates/etc/snapserver.conf.j2

--- a/roles/snapserver/templates/etc/snapserver.conf.j2
+++ b/roles/snapserver/templates/etc/snapserver.conf.j2
@@ -135,7 +135,11 @@ bind_to_address = ::
 # alsa: alsa://?name=<name>&device=<alsa device>[&send_silence=false][&idle_threshold=100]
 # meta: meta:///<name of source#1>/<name of source#2>/.../<name of source#N>?name=<name>
 #source = pipe:///tmp/snapfifo?name=mischpult
+{% if snapserver_controlscript is not defined or snapserver_controlscript == '' -%}
 source = {{ snapserver_sourcetype }}://?name={{ snapserver_name }}&device={{ snapserver_alsasource }}&send_silence=false&idle_threshold={{ snapserver_idle_threshold }}&silence_threshold_percent={{ snapserver_silence_threshold_percent}}
+{% else %}
+source = {{ snapserver_sourcetype }}://?name={{ snapserver_name }}&device={{ snapserver_alsasource }}&send_silence=false&idle_threshold={{ snapserver_idle_threshold }}&silence_threshold_percent={{ snapserver_silence_threshold_percent }}&controlscript={{ snapserver_controlscript }}{{ _snapserver_controlscript_params }}
+{% endif %}
 #source = tcp://127.0.0.1?name=mopidy_tcp
 
 # Default sample format
@@ -179,6 +183,6 @@ initial_volume = {{ snapserver_initial_volume }}
 
 # log filter <tag>:<level>[,<tag>:<level>]* 
 # with tag = * or <log tag> and level = [trace,debug,info,notice,warning,error,fatal]
-#filter = *:info
+filter = {{ _snapserver_log_filter }}*:info
 #
 ###############################################################################


### PR DESCRIPTION
* upgrade snapserver pkg to 0.34 
* supports mounting the mpd music directory via fstab (needs a user and password) to work around the non thread safeness in `smbclient`
* supports configuration of the Metadata-Plugin (aka "controlscript")  that enables Snapweb to display Audio Metadata (Title/Interpret/Cover) and controls ("previous", "play/pause", "next")

<img width="690" height="159" alt="Bildschirmfoto vom 2026-01-17 19-35-21" src="https://github.com/user-attachments/assets/ddf40438-4f97-4992-b333-81f3a4c3636b" />

